### PR TITLE
create nodeInput with a new approach

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-rules-io",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Generic rules node for Node-RED, that executes file-based rules",
     "dependencies": {},
     "keywords": [

--- a/rules-io/rules-io.js
+++ b/rules-io/rules-io.js
@@ -8,8 +8,10 @@ module.exports = function (RED) {
         var nodeContext = this.context();
         node.on('input', function (msg, send, done) {
             // Extract input values from the message. 
-            var nodeInput = msg;
-            delete nodeInput._msgid;
+            var nodeInput = {
+                "topic": msg.topic,
+                "payload": msg.payload
+            };
             // Create the log entry and write the first informations in it
             var logEntry = getLogEntry(this.name, this.rulesfilename, nodeInput)
             logEntry.metaInformation.previousInputOutput = "from context";


### PR DESCRIPTION
Node-RED added by their self the key "_event" to the input object. With this key the determination from the output object failed.

The key value pair nodeInput was created by copy the message and deleting of other keys as topic and payload. Yet nodeInput is created not by copy.